### PR TITLE
Only install Atom if it is not already installed

### DIFF
--- a/atom.symlink/install.sh
+++ b/atom.symlink/install.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
-if [ "$(uname -s)" = "Darwin" ]; then
-  brew cask install atom
-elif test "$(which yaourt)"; then
-  yaourt -S --noconfirm atom-editor
+
+# only install if not already installed
+if test ! "$(which atom)"; then
+  if [ "$(uname -s)" = "Darwin" ]; then
+    brew cask install atom
+  elif test "$(which yaourt)"; then
+    yaourt -S --noconfirm atom-editor
+  fi
 fi
 
 apm install \


### PR DESCRIPTION
Installing Atom through AUR takes a very long time when it is already
installed, so I'm skipping installing it if it is already instaleld.
