### PR TITLE
update to gitlab 16+ lint API 

### DIFF
--- a/bin/gitlab-ci-render
+++ b/bin/gitlab-ci-render
@@ -45,7 +45,7 @@
                     str/trim)))
 
 (def project-id (or (System/getenv "CI_PROJECT_ID")
-               (->> @(process `("glab" "--host" ~git-host "variable" "CI_PROJECT_ID"))
+               (->> @(process `("glab" "--host" ~git-host "variable" "get" "CI_PROJECT_ID"))
                     :out
                     slurp
                     str/trim)))

--- a/bin/gitlab-ci-render
+++ b/bin/gitlab-ci-render
@@ -44,7 +44,7 @@
                     slurp
                     str/trim)))
 
-(def project-id (or (System/getenv "GI_PROJECT_ID")
+(def project-id (or (System/getenv "CI_PROJECT_ID")
                (->> @(process `("glab" "--host" ~git-host "variable" "CI_PROJECT_ID"))
                     :out
                     slurp

--- a/bin/gitlab-ci-render
+++ b/bin/gitlab-ci-render
@@ -44,7 +44,13 @@
                     slurp
                     str/trim)))
 
-(let [url (str "https://" git-host "/api/v4/ci/lint")
+(def project-id (or (System/getenv "GI_PROJECT_ID")
+               (->> @(process `("glab" "--host" ~git-host "variable" "CI_PROJECT_ID"))
+                    :out
+                    slurp
+                    str/trim)))
+
+(let [url (str "https://" git-host "/api/v4/projects/" project-id "/ci/lint")
       body (json/generate-string {"content" gitlab-ci-json})
       output-formatter (case (get-in cli [:options :output])
                          "json" #(json/generate-string (yaml/parse-string %) {:pretty true})


### PR DESCRIPTION
The `POST ci/lint` API endpoint is deprecated in GitLab 15.7, and removed in 16.0. This endpoint does not validate the full range of CI/CD configuration options.

Instead, it should use the project-specific [POST /projects/:id/ci/lint](https://docs.gitlab.com/ee/api/lint.html#validate-a-ci-yaml-configuration-with-a-namespace), which properly validates CI/CD configuration.